### PR TITLE
Sequel now correctly interprets arrays as postgres arrays

### DIFF
--- a/lib/rack/push-notification.rb
+++ b/lib/rack/push-notification.rb
@@ -22,6 +22,7 @@ module Rack
         Sequel.extension :pg_array, :migration
 
         DB = Sequel.connect(ENV['DATABASE_URL'])
+        DB.extend Sequel::Postgres::PGArray::DatabaseMethods
         Sequel::Migrator.run(DB, ::File.join(::File.dirname(__FILE__), 'push-notification/migrations'), table: 'push_notification_schema_info')
       end
     end


### PR DESCRIPTION
Before, the pg_arrays Sequel extension wasn't being loaded correctly to utilize arrays in the model. 

This fixes `Sequel::DatabaseError - PG::Error: ERROR:  missing dimension value` showing up when receiving the `tags` array from Orbiter, etc.

Fixes helios-framework/helios#21

[source](http://www.ruby-forum.com/topic/3984710)
