### PR TITLE
Clarify just what the heck rails-database-url is

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A device's `locale` & `language` can be used to localize outgoing communications
 
 ## Example Usage
 
-Rack::PushNotification can be run as Rack middleware or as a single web application. All that is required is a connection to a Postgres database. You must define this with the environment variable `DATABASE_URL`. For rails, use the `rails-database-url` to define this from the `database.yml`.
+Rack::PushNotification can be run as Rack middleware or as a single web application. All that is required is a connection to a Postgres database. You must define this with the environment variable `DATABASE_URL`. For rails, use the [`rails-database-url`](https://github.com/glenngillen/rails-database-url) gem to define this from the `database.yml`.
 
 ### config.ru
 


### PR DESCRIPTION
I was confused a bit by this line because it didn't say what `rails-database-url` is. A quick google showed me it's a gem with a Github repo. I added a link to this repo here to help clear up any future confusion.
