### PR TITLE
Place extension call after database connection is made

### DIFF
--- a/lib/rack/push-notification.rb
+++ b/lib/rack/push-notification.rb
@@ -18,9 +18,9 @@ module Rack
     configure do
       if ENV['DATABASE_URL']
         Sequel.extension :pg_inet, :migration
-        Sequel::Model.db.extension :pg_array
 
         DB = Sequel.connect(ENV['DATABASE_URL'])
+        Sequel::Model.db.extension :pg_array
         DB.extend Sequel::Postgres::PGArray::DatabaseMethods
         Sequel::Migrator.run(DB, ::File.join(::File.dirname(__FILE__), 'push-notification/migrations'), table: 'push_notification_schema_info')
       end


### PR DESCRIPTION
After change made in 0.52, attempting to require in rack/push_notification results in:

```
.../gems/sequel-4.11.0/lib/sequel/model/base.rb:226:in `db': No database associated with Sequel::Model: have you called Sequel.connect or Sequel::Model.db= ? (Sequel::Error)
from .../rack-push-notification/lib/rack/push-notification.rb:21:in `block in <class:PushNotification>'
```

Needed to move the extension call below the connect method.